### PR TITLE
Update to v3.0 with citation rendering fix

### DIFF
--- a/renderLatex.user.js
+++ b/renderLatex.user.js
@@ -1,101 +1,131 @@
 // ==UserScript==
-// @name         Render LaTeX in NotebookLM
+// @name         NotebookLM LaTeX Renderer 3.0
 // @namespace    http://tampermonkey.net/
-// @version      2.0
-// @description  A minimal, stable, and robust renderer focusing solely on perfect LaTeX display without extra features.
-// @author       ergs0204 (with Zolangui modifications)
+// @version      3.0
+// @description  The definitive stable version. Detaches all citations from a paragraph, renders the math, then re-appends citations at the end to ensure perfect rendering and preservation.
+// @author       ergs0204, Zolangui
 // @match        https://notebooklm.google.com/*
-// @grant        GM_addStyle
 // @require      https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js
 // @require      https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js
-// @resource     katexCSS https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css
-// @license      MIT
+// @require      https://github.com/sizzlemctwizzle/GM_config/raw/master/gm_config.js
+// @resource     KATEX_CSS https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css
+// @grant        GM_getResourceText
+// @grant        GM_addStyle
+// @grant        GM_registerMenuCommand
+// @grant        GM_setValue
+// @grant        GM_getValue
+// @run-at       document-idle
 // ==/UserScript==
 
-(function () {
+(function() {
     'use strict';
 
-    const addKaTeXStyles = () => {
-        const katexLink = document.createElement('link');
-        katexLink.rel = 'stylesheet';
-        katexLink.href = 'https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css';
-        document.head.appendChild(katexLink);
-    };
+    const PROCESSED_CLASS = 'latex-processed-by-userscript';
 
-    const addCustomStyles = () => {
-        const css = `.katex { vertical-align: -0.1em; }`;
-        GM_addStyle(css);
-    };
+    GM_config.init({
+        id: 'NotebookLM_LaTeX_Config',
+        title: 'LaTeX Renderer Settings',
+        fields: {
+            'contentSelector': { 'label': 'Content Paragraph Selector', 'type': 'text', 'default': 'div.paragraph' },
+            'chipSelector': { 'label': 'Citation Chip Selector', 'type': 'text', 'default': 'button.citation-marker' },
+            'debounceTime': { 'label': 'Render Debounce Time (ms)', 'type': 'int', 'default': 300, 'min': 50 }
+        },
+        events: {
+            'save': () => { GM_config.close(); location.reload(); },
+            'init': main
+        }
+    });
 
-    const preprocessAndSanitize = (node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-            let originalText = node.nodeValue;
-            let newText = originalText;
+    function main() {
+        const CONFIG = {
+            CONTENT_SELECTOR: GM_config.get('contentSelector'),
+            CHIP_SELECTOR: GM_config.get('chipSelector'),
+            DEBOUNCE_TIME: GM_config.get('debounceTime')
+        };
 
-            const displayMathRegex = /\$\$(.*?)\$\$/gs;
-            let tempTextForDisplay = newText;
-            let match_display;
-            while ((match_display = displayMathRegex.exec(tempTextForDisplay)) !== null) {
-                const content = match_display[1].trim();
-                const isComplex = content.length > 25 || content.includes('\\begin') || content.includes('\\frac') || content.includes('\\sum') || content.includes('\\int') || content.includes('\\lim') || content.includes('\\\\') || content.split(' ').length > 4;
-                if (!isComplex) {
-                    newText = newText.replace(`$$${match_display[1]}$$`, `$${content}$`);
-                }
-            }
+        try {
+            let katexCSS = GM_getResourceText("KATEX_CSS");
+            const fontURLPrefix = `https://cdn.jsdelivr.net/npm/katex@${katex.version}/dist/`;
+            katexCSS = katexCSS.replace(/url\(fonts\//g, `url(${fontURLPrefix}fonts/`);
+            GM_addStyle(katexCSS);
+            GM_addStyle('.katex { font-size: 1.3em; vertical-align: -0.1em; }');
+        } catch (e) {
+            console.error("[NLM-LaTeX|ERROR]", "Failed to inject KaTeX CSS.", e);
+        }
 
-            if (newText !== originalText) {
-                node.nodeValue = newText;
-            }
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-            if (['SCRIPT', 'STYLE', 'TEXTAREA', 'PRE', 'CODE'].includes(node.tagName)) {
+        const katexOptions = {
+            delimiters: [
+                { left: "$$", right: "$$", display: true }, { left: "\\[", right: "\\]", display: true },
+                { left: "$", right: "$", display: false }, { left: "\\(", right: "\\)", display: false }
+            ],
+            throwOnError: false,
+        };
+
+        const processParagraph = (p) => {
+            if (p.classList.contains(PROCESSED_CLASS) || !p.textContent.includes('$')) {
                 return;
             }
-            for (const child of Array.from(node.childNodes)) {
-                preprocessAndSanitize(child);
+
+            const detachedMarkers = Array.from(p.querySelectorAll(CONFIG.CHIP_SELECTOR));
+            detachedMarkers.forEach(chip => chip.remove());
+
+            let child = p.firstChild;
+            while (child) {
+                if (child.nodeName === 'SPAN') {
+                    let nextRelevantSibling = child.nextSibling;
+                    while (nextRelevantSibling && (nextRelevantSibling.nodeType !== Node.ELEMENT_NODE || nextRelevantSibling.nodeName !== 'SPAN')) {
+                        nextRelevantSibling = nextRelevantSibling.nextSibling;
+                    }
+                    if (nextRelevantSibling) {
+                        child.textContent += nextRelevantSibling.textContent;
+                        let nodeToRemove = child.nextSibling;
+                        while (nodeToRemove !== nextRelevantSibling) {
+                            let temp = nodeToRemove.nextSibling;
+                            p.removeChild(nodeToRemove);
+                            nodeToRemove = temp;
+                        }
+                        if (nextRelevantSibling) p.removeChild(nextRelevantSibling);
+                        continue;
+                    }
+                }
+                child = child.nextSibling;
             }
-        }
-    };
+            p.normalize();
 
-    const ignoreClass = 'katex-ignore-active-render';
-    const katexOptions = {
-        delimiters: [
-            { left: "$$", right: "$$", display: true }, { left: "$", right: "$", display: false },
-            { left: "\\(", right: "\\)", display: false }, { left: "\\[", right: "\\]", display: true }
-        ],
-        ignoredClasses: [ignoreClass],
-        throwOnError: false
-    };
+            renderMathInElement(p, katexOptions);
 
-    let renderTimeout;
-    const renderPageWithIgnore = () => {
-        const activeEl = document.activeElement;
-        let hasIgnoreClass = false;
-        try {
-            if (activeEl && (activeEl.isContentEditable || activeEl.tagName === 'TEXTAREA' || activeEl.tagName === 'INPUT')) {
-                activeEl.classList.add(ignoreClass);
-                hasIgnoreClass = true;
+            if (detachedMarkers.length > 0) {
+                detachedMarkers.forEach(marker => {
+                    p.appendChild(marker);
+                    p.insertBefore(document.createTextNode(' '), marker);
+                });
             }
-            preprocessAndSanitize(document.body);
-            renderMathInElement(document.body, katexOptions);
-        } catch (e) {
-            console.error("KaTeX render error:", e);
-        } finally {
-            if (hasIgnoreClass && activeEl) {
-                activeEl.classList.remove(ignoreClass);
-            }
-        }
-    };
 
-    const observer = new MutationObserver(() => {
-        clearTimeout(renderTimeout);
-        renderTimeout = setTimeout(renderPageWithIgnore, 300);
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
+            p.classList.add(PROCESSED_CLASS);
+        };
 
-    window.addEventListener('load', () => {
-        addKaTeXStyles();
-        addCustomStyles();
-        renderPageWithIgnore();
-    });
+        let renderTimeout;
+        const observer = new MutationObserver((mutations) => {
+            clearTimeout(renderTimeout);
 
+            renderTimeout = setTimeout(() => {
+                document.querySelectorAll(`.${PROCESSED_CLASS}`).forEach(p => {
+                    if (!p.querySelector('.katex')) {
+                        p.classList.remove(PROCESSED_CLASS);
+                    }
+                });
+
+                document.querySelectorAll(CONFIG.CONTENT_SELECTOR).forEach(processParagraph);
+
+            }, CONFIG.DEBOUNCE_TIME);
+        });
+
+        const initialize = () => {
+            document.querySelectorAll(CONFIG.CONTENT_SELECTOR).forEach(processParagraph);
+            observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+        };
+
+        GM_registerMenuCommand('Configure LaTeX Renderer', () => GM_config.open());
+        initialize();
+    }
 })();


### PR DESCRIPTION
**### This pull request updates the script to version 3.0 and introduces a fundamental fix for the citation rendering bug.**

**Before**
![unnamed](https://github.com/user-attachments/assets/2d25e7b6-ed81-4df4-a042-90438c54c8b6)

**After**
![unnamed2](https://github.com/user-attachments/assets/378ea862-0bd7-4d9b-a461-7d85e647d66b)

The main change is the refactoring of the rendering logic to resolve a critical issue where citations (e.g., [1], [2]) would break LaTeX parsing when they appeared inside or near a mathematical expression. The script now temporarily removes all citations from a paragraph, renders the LaTeX in the clean text, and then appends the citations back to the end of the paragraph, ensuring perfect rendering.

**Known Issues**

Despite the main citation bug fix, some minor issues still persist and will be addressed in future versions. Due to a lack of time, the priority was to resolve the most critical issue that prevented the use of mathematical formulas along with NotebookLM's sources.

This update represents a major step forward in the stability and usability of LaTeX rendering in NotebookLM.