### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Tampermonkey userscript that adds LaTeX rendering capability to Google's Noteb
    - [Safari](https://apps.apple.com/us/app/tampermonkey/id1482490089)
    
     > [!IMPORTANT]  
-    > On Chromium-based browsers (Chrome, Brave, Vivaldi, Edge, Opera, etc.),  
+    > On some Chromium-based browsers (Chrome, Brave, Vivaldi, Edge, Opera, etc.),  
     > Tampermonkey will not run user scripts unless you explicitly enable:  
     > `Manage Extensions > Tampermonkey > Details > Allow User Scripts`  
     > Make sure this toggle is **ON**, otherwise the script will never execute.  

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ A Tampermonkey userscript that adds LaTeX rendering capability to Google's Noteb
    - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/)
    - [Edge](https://microsoftedge.microsoft.com/addons/detail/tampermonkey/iikmkjmpaadaobahmlepeloendndfphd)
    - [Safari](https://apps.apple.com/us/app/tampermonkey/id1482490089)
+   
+    > [!IMPORTANT]  
+    > On Chromium-based browsers (Chrome, Brave, Vivaldi, Edge, Opera, etc.),  
+    > Tampermonkey will not run user scripts unless you explicitly enable:  
+    > `Manage Extensions > Tampermonkey > Details > Allow User Scripts`  
+    > Make sure this toggle is **ON**, otherwise the script will never execute.  
 
 2. Install the script:
    - **Recommended**: Click [here](https://raw.githubusercontent.com/ergs0204/LatexInNotebooklm/refs/heads/main/renderLatex.user.js) to install via `.user.js` file


### PR DESCRIPTION
Some Chromium-based browsers (Chrome, Brave, Vivaldi, etc.) require explicitly enabling "Allow User Scripts" for Tampermonkey, otherwise user scripts will not run at all.

This PR updates the README to add clear instructions:
- How to enable "Allow User Scripts"
- Clarifies that this applies only to Chromium-based browsers
- This may also reduce the number of users opening issues claiming that "the script does not work," since often the real cause is that the toggle was left disabled.

<img width="674" height="81" alt="image" src="https://github.com/user-attachments/assets/0383cec5-6457-4bc2-b648-60e27f8579a6" />
